### PR TITLE
work around pin_subpackage(..., exact=True) in run_constrained

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,5 @@
 {% set version = "0.13.2" %}
+{% set build = 2 %}
 
 package:
   name: seaborn-split
@@ -9,7 +10,7 @@ source:
   sha256: 93e60a40988f4d65e9f4885df477e2fdaff6b73a9ded434c1ab356dd57eefff7
 
 build:
-  number: 1
+  number: {{ build }}
   noarch: python
 
 test:
@@ -38,7 +39,9 @@ outputs:
         - scipy >=1.7
         - pandas >=1.2
       run_constrained:
-        - {{ pin_subpackage('seaborn', exact=True) }}        
+        # should be {{ pin_subpackage("seaborn", exact=True) }}
+        # but this seems to be broken right now: https://github.com/conda/conda-build/issues/4415
+        - seaborn ={{ version }}=*_{{ build }}
       test:
         imports:
           - seaborn


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Fix suggested by @jaimergp here: https://github.com/conda-forge/seaborn-feedstock/pull/35#issuecomment-2083702754. Due to my own insecurity copy-pasted from here :grimacing: https://github.com/conda-forge/nbconvert-feedstock/blob/main/recipe/meta.yaml#L93-L95.

@jaimergp could you sanity-check this for me please?

I should probably start writing a memoir about multi-output packages at some point, they burned me in so many unexpected ways already 😬